### PR TITLE
Include seaborn dependency (currently missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Libraries.io:
 - matplotlib>=3.4.3
 - numpy
 - pandas
+- seaborn
 ```
 pip install --ignore-install matplotlib==3.5.1 numpy==1.20.3 pandas==1.4.1
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0","matplotlib>=3.5.1","numpy>=1.20.3","pandas>=1.4.1"]
+requires = ["setuptools>=61.0","matplotlib>=3.5.1","numpy>=1.20.3","pandas>=1.4.1", "seaborn>=0.12.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
@DingWB, seaborn dependency is not present in the pyproject file. Hence, this PR adds seaborn to the list. 