### PR TITLE
update anno_img: add a parameter merge and merge_width. assert if all the images have the same shape.

### DIFF
--- a/PyComplexHeatmap/annotations.py
+++ b/PyComplexHeatmap/annotations.py
@@ -1154,8 +1154,6 @@ class anno_img(AnnotationBase):
 			assert img.shape[:2] == (height, width), \
 				f"The image size of {imgfile} differs. Reference: ({height}, {width}), Current image: {img.shape[:2]}"
 
-		w = width
-
 	def plot(self, ax=None, axis=1):
 		import matplotlib.image as mpimg
 		if ax is None:

--- a/PyComplexHeatmap/annotations.py
+++ b/PyComplexHeatmap/annotations.py
@@ -1170,6 +1170,7 @@ class anno_img(AnnotationBase):
 			else:
 				extent = [0, img_h, self.nrows/2-self.merge_width/2, self.nrows/2+self.merge_width/2]
 		else:
+			self._check_imgfiles(imgfiles)
 			if axis==1:
 				imgs = np.hstack(tuple([self._add_border(mpimg.imread(imgfile), 
                                                 width=self.border_width, color=self.border_color, axis=axis) \

--- a/PyComplexHeatmap/annotations.py
+++ b/PyComplexHeatmap/annotations.py
@@ -1084,9 +1084,14 @@ class anno_img(AnnotationBase):
 	Parameters
 	----------
 	border_width : int
-		width of border lines between images (0-256?).
+		width of border lines between images (0-256?). Ignored when merge is True.
 	border_color : int
-		color of border lines. black:0, white:255.
+		color of border lines. black:0, white:255. Ignored when merge is True.
+	merge: bool
+		whether to merge the same clusters into one and show image only once.
+	merge_width: float
+        width of image when merge is True
+		whether to merge the same clusters into one and show image only once.
 	"""
 	def __init__(
 		self,
@@ -1095,6 +1100,8 @@ class anno_img(AnnotationBase):
 		colors=None,
         border_width=1,
 		border_color=255,
+        merge=False,
+        merge_width=1,
 		height=None,
 		legend=True,
 		legend_kws=None,
@@ -1102,6 +1109,8 @@ class anno_img(AnnotationBase):
 	):
 		self.border_width = border_width
 		self.border_color = border_color
+		self.merge = merge
+		self.merge_width = merge_width
 
 		self.plot_kws = plot_kws
 		super().__init__(
@@ -1137,6 +1146,15 @@ class anno_img(AnnotationBase):
 						mode='constant', constant_values=color)
 		return bordered_img
 
+	def _check_imgfiles(self, imgfiles):
+		first_image = mpimg.imread(imgfiles[0])
+		height, width = first_image.shape[:2]
+		for imgfile in imgfiles[1:]:
+			img = mpimg.imread(imgfile)
+			assert img.shape[:2] == (height, width), \
+				f"The image size of {imgfile} differs. Reference: ({height}, {width}), Current image: {img.shape[:2]}"
+
+		w = width
 
 	def plot(self, ax=None, axis=1):
 		import matplotlib.image as mpimg
@@ -1144,26 +1162,28 @@ class anno_img(AnnotationBase):
 			ax = plt.gca()
 		imgfiles = list(self.plot_data.iloc[:,0])
 		img_h = mpimg.imread(imgfiles[0]).shape[1]
-		if axis==1:
-			imgs = np.hstack(tuple([self._add_border(mpimg.imread(imgfile), 
-											width=self.border_width, color=self.border_color, axis=axis) \
-						   for imgfile in imgfiles]))
+		if self.merge:
+			assert all(imgfile == imgfiles[0] for imgfile in imgfiles), "Not all file names in the list are identical"
+			imgs = mpimg.imread(imgfiles[0])
+			if axis==1:
+				extent = [self.nrows/2-self.merge_width/2, self.nrows/2+self.merge_width/2, 0, img_h]
+			else:
+				extent = [0, img_h, self.nrows/2-self.merge_width/2, self.nrows/2+self.merge_width/2]
 		else:
-			imgs = np.vstack(tuple([self._add_border(mpimg.imread(imgfile), 
-											width=self.border_width, color=self.border_color, axis=axis) \
-						   for imgfile in imgfiles]))
-
-		if axis==1:
-			extent = [0, self.nrows, 0, img_h]
-		else:
-			extent = [0, img_h, 0, self.nrows]
+			if axis==1:
+				imgs = np.hstack(tuple([self._add_border(mpimg.imread(imgfile), 
+                                                width=self.border_width, color=self.border_color, axis=axis) \
+                            for imgfile in imgfiles]))
+				extent = [0, self.nrows, 0, img_h]
+			else:
+				imgs = np.vstack(tuple([self._add_border(mpimg.imread(imgfile), 
+                                                width=self.border_width, color=self.border_color, axis=axis) \
+                            for imgfile in imgfiles]))
+				extent = [0, img_h, 0, self.nrows]
 
 		ax.imshow(imgs, aspect='auto', extent=extent, cmap=self.cmap, **self.plot_kws)
 
-		if axis==1:
-			#ax.invert_yaxis()
-			pass
-		else:
+		if axis==0:
 			ax.invert_yaxis()
 
 		ax.tick_params(labelbottom=False, labelleft=False, labelright=False, labeltop=False)


### PR DESCRIPTION
Hi Wubin,

Thanks for merging the pull request and adding the use of `anno_img` to the documentation. I appreciate your feedback and suggestions.

Regarding the image size issue, my approach assumes that all images are exactly the same size. If this is not the case, the current code will indeed encounter errors during the `np.hstack` or `np.vstack` operations. To address situations where images may vary in size and aspect ratio, implementing a comprehensive solution becomes complex. Therefore, I decided to use assertions to enforce that images within the same cluster must have identical sizes.

https://github.com/dakomura/PyComplexHeatmap/blob/951ecb9f15d765bdd3f811dd228d8c1e7cb744ac/PyComplexHeatmap/annotations.py#L1149-L1155


As for the `merge` parameter, while the need to merge images is rare, there are scenarios where it could be beneficial to display a single image for a particular category or cluster. Since the implementation was straightforward, I included this feature.

https://github.com/dakomura/PyComplexHeatmap/blob/951ecb9f15d765bdd3f811dd228d8c1e7cb744ac/PyComplexHeatmap/annotations.py#L1163-L1169

```
df = pd.DataFrame(['AAAA1'] * 5 + ['BBBBB2'] * 5, columns=['AB'])
df['CD'] = ['C'] * 3 + ['D'] * 3 + ['G'] * 4
df['F'] = np.random.normal(0, 1, 10)
df.index = ['sample' + str(i) for i in range(1, df.shape[0] + 1)]
df_box = pd.DataFrame(np.random.randn(10, 4), columns=['Gene' + str(i) for i in range(1, 5)])
df_box.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar = pd.DataFrame(np.random.uniform(0, 10, (10, 2)), columns=['TMB1', 'TMB2'])
df_bar.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_scatter = pd.DataFrame(np.random.uniform(0, 10, 10), columns=['Scatter'])
df_scatter.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar1 = pd.DataFrame(np.random.uniform(0, 10, (10, 2)), columns=['T1-A', 'T1-B'])
df_bar1.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar2 = pd.DataFrame(np.random.uniform(0, 10, (10, 2)), columns=['T2-A', 'T2-B'])
df_bar2.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar3 = pd.DataFrame(np.random.uniform(0, 10, (10, 2)), columns=['T3-A', 'T3-B'])
df_bar3.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar3.iloc[5,0]=np.nan
df_bar4 = pd.DataFrame(np.random.uniform(0, 10, (10, 1)), columns=['T4'])
df_bar4.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_bar4.iloc[7,0]=np.nan
df_img = pd.DataFrame([f"{i:02}.jpg" for i in range(1,11)], columns=['path'])
df_img.index = ['sample' + str(i) for i in range(1, df_box.shape[0] + 1)]
df_heatmap = pd.DataFrame(np.random.randn(30, 10), columns=['sample' + str(i) for i in range(1, 11)])
df_heatmap.index = ["Fea" + str(i) for i in range(1, df_heatmap.shape[0] + 1)]
df_heatmap.iloc[1, 2] = np.nan

plt.figure(figsize=(12, 16))

#df_img_col = pd.DataFrame([f"{i:02}.jpg" for i in range(10)], columns=['Image'])
df_img_col = pd.DataFrame([f"01.jpg" for i in range(10)], columns=['Image'])
df_img_col.index = ['sample' + str(i) for i in range(1, 11)]
#df_img_row = pd.DataFrame([f"{i:02}.jpg" for i in range(30)], columns=['Image'])
df_img_row = pd.DataFrame([f"02.jpg" for i in range(30)], columns=['Image'])
df_img_row.index = ["Fea" + str(i) for i in range(1, df_heatmap.shape[0] + 1)]

col_ha = HeatmapAnnotation(Image=anno_img(df_img_col,  height=16, border_width=10, merge=True, merge_width=1))#, axis=1)
row_ha = HeatmapAnnotation(Image=anno_img(df_img_row, border_width=13, merge=True, merge_width=2, height=20), axis=0)

cm = ClusterMapPlotter(data=df_heatmap, top_annotation=col_ha, left_annotation=row_ha, col_split=2, row_split=3, col_split_gap=10,
                     row_split_gap=10,label='values',row_dendrogram=True,show_rownames=True,show_colnames=True,
                     tree_kws={'row_cmap': 'Dark2'},cmap='Spectral_r',
                       legend_gap=5,legend_hpad=2,legend_vpad=5)
plt.show()
```

<img width="715" alt="merge_example" src="https://github.com/DingWB/PyComplexHeatmap/assets/25994892/b2bbdd83-6410-4c4f-a1be-50c009202ca8">


I will be sure to send you the Jupyter notebook when it is finished and contains a better example of `anno_img` used with real biological data. This example will be suitable for inclusion in the documentation website.

Best regards,

Daisuke