### PR TITLE
Add regression tests for inherited heatmap grids

### DIFF
--- a/tests/test_heatmap_grid.py
+++ b/tests/test_heatmap_grid.py
@@ -1,0 +1,63 @@
+import unittest
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.collections import QuadMesh
+
+from PyComplexHeatmap import heatmap
+from PyComplexHeatmap.clustermap import plot_heatmap
+
+
+class HeatmapGridTest(unittest.TestCase):
+    def tearDown(self):
+        plt.close("all")
+
+    def assert_grid_is_hidden(self, ax):
+        ax.figure.canvas.draw()
+        gridlines = [*ax.get_xgridlines(), *ax.get_ygridlines()]
+        self.assertFalse(any(line.get_visible() for line in gridlines))
+
+    def assert_cell_borders_remain(self, ax):
+        meshes = [
+            collection
+            for collection in ax.collections
+            if isinstance(collection, QuadMesh)
+        ]
+        self.assertEqual(len(meshes), 1)
+        self.assertTrue(np.any(np.asarray(meshes[0].get_linewidths()) > 0))
+
+    def test_heatmap_disables_inherited_axis_grid(self):
+        with matplotlib.rc_context({"axes.grid": True}):
+            _, ax = plt.subplots()
+            heatmap(
+                np.array([[1, 2], [3, 4]]),
+                ax=ax,
+                cbar=False,
+                linewidths=0.5,
+                linecolor="black",
+            )
+
+        self.assert_grid_is_hidden(ax)
+        self.assert_cell_borders_remain(ax)
+
+    def test_plot_heatmap_disables_inherited_axis_grid(self):
+        with matplotlib.rc_context({"axes.grid": True}):
+            _, ax = plt.subplots()
+            plot_heatmap(
+                np.array([[1, 2], [3, 4]]),
+                ax=ax,
+                cmap="viridis",
+                linewidths=0.5,
+                linecolor="black",
+            )
+
+        self.assert_grid_is_hidden(ax)
+        self.assert_cell_borders_remain(ax)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add regression coverage for the inherited-grid fix in #60 and upstream commit `02707c7`.

The tests simulate an external style with `matplotlib.rc_context({"axes.grid": True})` and cover both heatmap rendering paths:

- the public `heatmap()` function;
- the internal `plot_heatmap()` helper used by clustered heatmaps.

They verify that axis grid lines are hidden while cell borders controlled by `linewidths` remain present. The tests use the non-interactive Agg backend and do not add seaborn or Scanpy as dependencies.

## Verification

The latest GitHub version, including `02707c7`, passed the regression tests on:

- Ubuntu, macOS, and Windows;
- Python 3.11 and 3.12.

GitHub Actions run: https://github.com/XiaofengZhou16/PyComplexHeatmap/actions/runs/32280845810

Generated by Codex
